### PR TITLE
SEO/GEO + Meta Pixel: correcciones del sitio, 5 posts nuevos y tracking sin duplicados

### DIFF
--- a/ai.txt
+++ b/ai.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Citation: allowed

--- a/blog/_plantilla-nuevo-articulo/index.html
+++ b/blog/_plantilla-nuevo-articulo/index.html
@@ -69,6 +69,57 @@
 </head>
 <body>
 
+<!-- Meta Pixel. Mismo ID y mismo patrón anti-duplicados que el resto del sitio
+     (autoConfig apagado + Pixel/CAPI con el mismo event_id). Dispara PageView y
+     ViewContent con el título de este artículo, para poder armar en Meta la
+     audiencia "leyó el blog", más caliente que un visitante genérico. -->
+<script>
+!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+fbq('set', 'autoConfig', false, '467504537642622');
+fbq('init', '467504537642622');
+
+function makeEventId(prefix){
+  return prefix + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+}
+function getCookie(name){
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  return match ? match[2] : null;
+}
+function sendCapiEvent(eventName, eventId, customData){
+  try{
+    fetch('/.netlify/functions/capi', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({
+        event_name: eventName,
+        event_id: eventId,
+        event_source_url: window.location.href,
+        custom_data: customData || undefined,
+        fbp: getCookie('_fbp'),
+        fbc: getCookie('_fbc')
+      })
+    }).catch(()=>{});
+  }catch(e){}
+}
+function trackBoth(eventName, params){
+  const id = makeEventId(eventName.toLowerCase());
+  fbq('track', eventName, params || {}, {eventID:id});
+  sendCapiEvent(eventName, id, params);
+}
+
+trackBoth('PageView');
+trackBoth('ViewContent', {content_name:'[TÍTULO DEL ARTÍCULO]', content_type:'article'});
+</script>
+<noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=467504537642622&ev=PageView&noscript=1"/></noscript>
+
+
 <header>
   <div class="nav wrap">
     <a class="logo" href="/"><img src="https://res.cloudinary.com/dplhu2z6j/image/upload/v1755314905/Marketographers_Negro_S_F_tgh9z2.png" alt="The Marketographers"></a>
@@ -137,6 +188,24 @@
     <p>© 2026 The Marketographers. Todos los putos derechos reservados.</p>
   </div>
 </footer>
+
+<!-- Mismo mapeo de eventos de clic que usa la landing principal: chat.whatsapp.com
+     (grupo gratuito) = Lead, api.whatsapp.com/wa.me (chat directo) = Contact,
+     nas.com/nas.io (checkout) = ClickCheckoutLanding. Un solo listener delegado. -->
+<script>
+  document.addEventListener('click', (e)=>{
+    const link = e.target.closest('a');
+    if(!link || !link.href) return;
+    if(link.href.includes('chat.whatsapp.com')){
+      trackBoth('Lead');
+    } else if(link.href.includes('api.whatsapp.com') || link.href.includes('wa.me')){
+      trackBoth('Contact');
+    }
+    if(link.href.includes('nas.com') || link.href.includes('nas.io')){
+      trackBoth('ClickCheckoutLanding');
+    }
+  });
+</script>
 
 </body>
 </html>

--- a/blog/boca-a-boca-no-es-estrategia/index.html
+++ b/blog/boca-a-boca-no-es-estrategia/index.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Por qué el boca a boca no es una estrategia de marketing | The Marketographers</title>
+<meta name="description" content="Vivir del boca a boca no es tener un negocio, es tener suerte con fecha de vencimiento. Por qué depender de las recomendaciones te deja sin control.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://marketographers.com/blog/boca-a-boca-no-es-estrategia/">
+
+<!-- Open Graph -->
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="The Marketographers">
+<meta property="og:title" content="Por qué el boca a boca no es una estrategia de marketing">
+<meta property="og:description" content="Vivir del boca a boca no es tener un negocio, es tener suerte con fecha de vencimiento.">
+<meta property="og:image" content="[URL_IMAGEN_PORTADA_1600x1000]">
+<meta property="og:url" content="https://marketographers.com/blog/boca-a-boca-no-es-estrategia/">
+<meta property="og:locale" content="es_LA">
+<meta property="article:author" content="Pablo Villarroel">
+<meta property="article:published_time" content="2026-08-18">
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Por qué el boca a boca no es una estrategia de marketing">
+<meta name="twitter:description" content="Vivir del boca a boca no es tener un negocio, es tener suerte con fecha de vencimiento.">
+<meta name="twitter:image" content="[URL_IMAGEN_PORTADA_1600x1000]">
+
+<!-- Favicon -->
+<link rel="icon" type="image/png" href="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png">
+<link rel="apple-touch-icon" href="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png">
+
+<!-- JSON-LD -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Por qué el boca a boca no es una estrategia de marketing",
+  "description": "Vivir del boca a boca no es tener un negocio, es tener suerte con fecha de vencimiento.",
+  "image": "[URL_IMAGEN_PORTADA_1600x1000]",
+  "author": { "@type": "Person", "name": "Pablo Villarroel" },
+  "publisher": {
+    "@type": "EducationalOrganization",
+    "name": "The Marketographers",
+    "logo": { "@type": "ImageObject", "url": "https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png" }
+  },
+  "datePublished": "2026-08-18",
+  "dateModified": "2026-08-18",
+  "mainEntityOfPage": "https://marketographers.com/blog/boca-a-boca-no-es-estrategia/"
+}
+</script>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/global.css">
+<link rel="stylesheet" href="/blog/assets/blog-extra.css">
+</head>
+<body>
+
+<!-- Meta Pixel. Mismo ID y mismo patrón anti-duplicados que el resto del sitio
+     (autoConfig apagado + Pixel/CAPI con el mismo event_id). Dispara PageView y
+     ViewContent con el título de este artículo, para poder armar en Meta la
+     audiencia "leyó el blog", más caliente que un visitante genérico. -->
+<script>
+!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+fbq('set', 'autoConfig', false, '467504537642622');
+fbq('init', '467504537642622');
+
+function makeEventId(prefix){
+  return prefix + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+}
+function getCookie(name){
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  return match ? match[2] : null;
+}
+function sendCapiEvent(eventName, eventId, customData){
+  try{
+    fetch('/.netlify/functions/capi', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({
+        event_name: eventName,
+        event_id: eventId,
+        event_source_url: window.location.href,
+        custom_data: customData || undefined,
+        fbp: getCookie('_fbp'),
+        fbc: getCookie('_fbc')
+      })
+    }).catch(()=>{});
+  }catch(e){}
+}
+function trackBoth(eventName, params){
+  const id = makeEventId(eventName.toLowerCase());
+  fbq('track', eventName, params || {}, {eventID:id});
+  sendCapiEvent(eventName, id, params);
+}
+
+trackBoth('PageView');
+trackBoth('ViewContent', {content_name:'Por qué el boca a boca no es una estrategia de marketing', content_type:'article'});
+</script>
+<noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=467504537642622&ev=PageView&noscript=1"/></noscript>
+
+<header>
+  <div class="nav wrap">
+    <a class="logo" href="/"><img src="https://res.cloudinary.com/dplhu2z6j/image/upload/v1755314905/Marketographers_Negro_S_F_tgh9z2.png" alt="The Marketographers"></a>
+    <div class="nav-actions">
+      <a class="btn btn-whatsapp" href="https://api.whatsapp.com/send?phone=+59169422335&text=%C2%A1Hola%2C%20Pablo!%20Vi%20tu%20blog%20y%20quiero%20m%C3%A1s%20info%20de%20la%20membres%C3%ADa%20de%20marketing%20para%20fot%C3%B3grafos" target="_blank" rel="noopener">WhatsApp</a>
+      <a class="btn btn-gold" href="/#planes">Únete</a>
+    </div>
+  </div>
+</header>
+
+<article>
+  <div class="article-hero">
+    <div class="wrap">
+      <span class="eyebrow eyebrow-red">Posicionamiento</span>
+      <h1>Por qué el boca a boca no es una estrategia de marketing</h1>
+      <div class="article-meta">
+        <span>Pablo Villarroel</span>
+        <span>18 de agosto, 2026</span>
+        <span>5 min de lectura</span>
+      </div>
+    </div>
+    <div class="wrap">
+      <div class="article-cover img-placeholder" style="aspect-ratio:16/9;">
+        <span class="ph-tag">Imagen por reemplazar</span>
+        Portada del artículo — 1600×900px, formato WebP comprimido
+      </div>
+    </div>
+  </div>
+
+  <div class="article-body">
+    <div class="wrap-article">
+
+      <p>"A mí me funciona el boca a boca" es la frase que más escucho justo antes de que un fotógrafo tenga un mes sin un solo cliente nuevo. No es contradicción, es la definición exacta del problema: el boca a boca no falla poco a poco, funciona bien hasta que un mes, sin avisar, deja de funcionar.</p>
+
+      <h2>El boca a boca no lo controlas tú</h2>
+      <p>Depender del boca a boca es depender de que otras personas se acuerden de ti, en el momento correcto, frente a la persona correcta, y además se tomen la molestia de recomendarte. Ninguna de esas tres cosas está en tus manos. Es marketing, pero delegado por completo en la memoria y la generosidad ajena.</p>
+
+      <blockquote>Si tu única fuente de clientes nuevos es que alguien se acuerde de ti, tu negocio no tiene un plan, tiene una esperanza.</blockquote>
+
+      <h2>Lo que sí puedes controlar</h2>
+      <p>Un sistema de marketing no reemplaza al boca a boca, lo complementa con canales que sí dependen de ti:</p>
+      <ul>
+        <li><strong>Contenido que te posiciona.</strong> Publicaciones y artículos que respondan las preguntas reales que se hace tu cliente antes de contratar, para que te encuentren sin que nadie te tenga que recomendar.</li>
+        <li><strong>Un lugar donde aterrizan esos clientes.</strong> Una landing o portafolio que convierte visitas en conversaciones, no solo "me gusta".</li>
+        <li><strong>Un proceso de venta repetible.</strong> Los mismos pasos, el mismo guion de cotización, cada vez, en vez de improvisar según el humor del día.</li>
+      </ul>
+
+      <h2>El boca a boca sigue sirviendo, como bono</h2>
+      <p>No se trata de apagar el boca a boca, se trata de dejar de necesitarlo para sobrevivir el mes. Cuando ya tienes un sistema que te trae clientes de forma predecible, cada recomendación que llega es una venta extra, no la única fuente de ingresos con la que cuentas.</p>
+
+    </div>
+  </div>
+
+  <div class="wrap-article">
+    <div class="article-cta">
+      <h3>¿Tu agenda depende de que alguien se acuerde de ti?</h3>
+      <p>Eso tiene arreglo, y no empieza con gastar en anuncios.</p>
+      <a class="btn btn-gold" href="https://api.whatsapp.com/send?phone=+59169422335&text=%C2%A1Hola%2C%20Pablo!%20Le%C3%AD%20el%20art%C3%ADculo%20del%20boca%20a%20boca%20y%20quiero%20saber%20m%C3%A1s%20de%20la%20comunidad" target="_blank" rel="noopener">Escríbeme por WhatsApp →</a>
+    </div>
+  </div>
+</article>
+
+<footer>
+  <div class="wrap">
+    <img src="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png" alt="The Marketographers" loading="lazy">
+    <p>© 2026 The Marketographers. Todos los putos derechos reservados.</p>
+  </div>
+</footer>
+
+<!-- Mismo mapeo de eventos de clic que usa la landing principal: chat.whatsapp.com
+     (grupo gratuito) = Lead, api.whatsapp.com/wa.me (chat directo) = Contact,
+     nas.com/nas.io (checkout) = ClickCheckoutLanding. Un solo listener delegado. -->
+<script>
+  document.addEventListener('click', (e)=>{
+    const link = e.target.closest('a');
+    if(!link || !link.href) return;
+    if(link.href.includes('chat.whatsapp.com')){
+      trackBoth('Lead');
+    } else if(link.href.includes('api.whatsapp.com') || link.href.includes('wa.me')){
+      trackBoth('Contact');
+    }
+    if(link.href.includes('nas.com') || link.href.includes('nas.io')){
+      trackBoth('ClickCheckoutLanding');
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/blog/como-cobrar-mas-sin-bajar-precio/index.html
+++ b/blog/como-cobrar-mas-sin-bajar-precio/index.html
@@ -101,6 +101,57 @@
 </head>
 <body>
 
+<!-- Meta Pixel. Mismo ID y mismo patrón anti-duplicados que el resto del sitio
+     (autoConfig apagado + Pixel/CAPI con el mismo event_id). Dispara PageView y
+     ViewContent con el título de este artículo, para poder armar en Meta la
+     audiencia "leyó el blog", más caliente que un visitante genérico. -->
+<script>
+!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+fbq('set', 'autoConfig', false, '467504537642622');
+fbq('init', '467504537642622');
+
+function makeEventId(prefix){
+  return prefix + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+}
+function getCookie(name){
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  return match ? match[2] : null;
+}
+function sendCapiEvent(eventName, eventId, customData){
+  try{
+    fetch('/.netlify/functions/capi', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({
+        event_name: eventName,
+        event_id: eventId,
+        event_source_url: window.location.href,
+        custom_data: customData || undefined,
+        fbp: getCookie('_fbp'),
+        fbc: getCookie('_fbc')
+      })
+    }).catch(()=>{});
+  }catch(e){}
+}
+function trackBoth(eventName, params){
+  const id = makeEventId(eventName.toLowerCase());
+  fbq('track', eventName, params || {}, {eventID:id});
+  sendCapiEvent(eventName, id, params);
+}
+
+trackBoth('PageView');
+trackBoth('ViewContent', {content_name:'Por qué bajar tus precios no te trae más clientes', content_type:'article'});
+</script>
+<noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=467504537642622&ev=PageView&noscript=1"/></noscript>
+
+
 <header>
   <div class="nav wrap">
     <a class="logo" href="/"><img src="https://res.cloudinary.com/dplhu2z6j/image/upload/v1755314905/Marketographers_Negro_S_F_tgh9z2.png" alt="The Marketographers"></a>
@@ -193,6 +244,24 @@
     <p>© 2026 The Marketographers. Todos los putos derechos reservados.</p>
   </div>
 </footer>
+
+<!-- Mismo mapeo de eventos de clic que usa la landing principal: chat.whatsapp.com
+     (grupo gratuito) = Lead, api.whatsapp.com/wa.me (chat directo) = Contact,
+     nas.com/nas.io (checkout) = ClickCheckoutLanding. Un solo listener delegado. -->
+<script>
+  document.addEventListener('click', (e)=>{
+    const link = e.target.closest('a');
+    if(!link || !link.href) return;
+    if(link.href.includes('chat.whatsapp.com')){
+      trackBoth('Lead');
+    } else if(link.href.includes('api.whatsapp.com') || link.href.includes('wa.me')){
+      trackBoth('Contact');
+    }
+    if(link.href.includes('nas.com') || link.href.includes('nas.io')){
+      trackBoth('ClickCheckoutLanding');
+    }
+  });
+</script>
 
 </body>
 </html>

--- a/blog/como-conseguir-clientes-sin-ads/index.html
+++ b/blog/como-conseguir-clientes-sin-ads/index.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Cómo conseguir clientes de fotografía sin gastar en anuncios | The Marketographers</title>
+<meta name="description" content="Antes de poner un peso en anuncios hay trabajo gratis que la mayoría de fotógrafos se salta. Tres formas de conseguir clientes sin presupuesto de ads.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://marketographers.com/blog/como-conseguir-clientes-sin-ads/">
+
+<!-- Open Graph -->
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="The Marketographers">
+<meta property="og:title" content="Cómo conseguir clientes de fotografía sin gastar en anuncios">
+<meta property="og:description" content="Tres formas de conseguir clientes nuevos antes de poner el primer peso en publicidad.">
+<meta property="og:image" content="[URL_IMAGEN_PORTADA_1600x1000]">
+<meta property="og:url" content="https://marketographers.com/blog/como-conseguir-clientes-sin-ads/">
+<meta property="og:locale" content="es_LA">
+<meta property="article:author" content="Pablo Villarroel">
+<meta property="article:published_time" content="2026-08-18">
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Cómo conseguir clientes de fotografía sin gastar en anuncios">
+<meta name="twitter:description" content="Tres formas de conseguir clientes nuevos antes de poner el primer peso en publicidad.">
+<meta name="twitter:image" content="[URL_IMAGEN_PORTADA_1600x1000]">
+
+<!-- Favicon -->
+<link rel="icon" type="image/png" href="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png">
+<link rel="apple-touch-icon" href="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png">
+
+<!-- JSON-LD -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Cómo conseguir clientes de fotografía sin gastar en anuncios",
+  "description": "Tres formas de conseguir clientes nuevos antes de poner el primer peso en publicidad.",
+  "image": "[URL_IMAGEN_PORTADA_1600x1000]",
+  "author": { "@type": "Person", "name": "Pablo Villarroel" },
+  "publisher": {
+    "@type": "EducationalOrganization",
+    "name": "The Marketographers",
+    "logo": { "@type": "ImageObject", "url": "https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png" }
+  },
+  "datePublished": "2026-08-18",
+  "dateModified": "2026-08-18",
+  "mainEntityOfPage": "https://marketographers.com/blog/como-conseguir-clientes-sin-ads/"
+}
+</script>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/global.css">
+<link rel="stylesheet" href="/blog/assets/blog-extra.css">
+</head>
+<body>
+
+<!-- Meta Pixel. Mismo ID y mismo patrón anti-duplicados que el resto del sitio
+     (autoConfig apagado + Pixel/CAPI con el mismo event_id). Dispara PageView y
+     ViewContent con el título de este artículo, para poder armar en Meta la
+     audiencia "leyó el blog", más caliente que un visitante genérico. -->
+<script>
+!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+fbq('set', 'autoConfig', false, '467504537642622');
+fbq('init', '467504537642622');
+
+function makeEventId(prefix){
+  return prefix + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+}
+function getCookie(name){
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  return match ? match[2] : null;
+}
+function sendCapiEvent(eventName, eventId, customData){
+  try{
+    fetch('/.netlify/functions/capi', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({
+        event_name: eventName,
+        event_id: eventId,
+        event_source_url: window.location.href,
+        custom_data: customData || undefined,
+        fbp: getCookie('_fbp'),
+        fbc: getCookie('_fbc')
+      })
+    }).catch(()=>{});
+  }catch(e){}
+}
+function trackBoth(eventName, params){
+  const id = makeEventId(eventName.toLowerCase());
+  fbq('track', eventName, params || {}, {eventID:id});
+  sendCapiEvent(eventName, id, params);
+}
+
+trackBoth('PageView');
+trackBoth('ViewContent', {content_name:'Cómo conseguir clientes de fotografía sin gastar en anuncios', content_type:'article'});
+</script>
+<noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=467504537642622&ev=PageView&noscript=1"/></noscript>
+
+<header>
+  <div class="nav wrap">
+    <a class="logo" href="/"><img src="https://res.cloudinary.com/dplhu2z6j/image/upload/v1755314905/Marketographers_Negro_S_F_tgh9z2.png" alt="The Marketographers"></a>
+    <div class="nav-actions">
+      <a class="btn btn-whatsapp" href="https://api.whatsapp.com/send?phone=+59169422335&text=%C2%A1Hola%2C%20Pablo!%20Vi%20tu%20blog%20y%20quiero%20m%C3%A1s%20info%20de%20la%20membres%C3%ADa%20de%20marketing%20para%20fot%C3%B3grafos" target="_blank" rel="noopener">WhatsApp</a>
+      <a class="btn btn-gold" href="/#planes">Únete</a>
+    </div>
+  </div>
+</header>
+
+<article>
+  <div class="article-hero">
+    <div class="wrap">
+      <span class="eyebrow eyebrow-red">Captación de clientes</span>
+      <h1>Cómo conseguir clientes de fotografía sin gastar en anuncios (todavía)</h1>
+      <div class="article-meta">
+        <span>Pablo Villarroel</span>
+        <span>18 de agosto, 2026</span>
+        <span>6 min de lectura</span>
+      </div>
+    </div>
+    <div class="wrap">
+      <div class="article-cover img-placeholder" style="aspect-ratio:16/9;">
+        <span class="ph-tag">Imagen por reemplazar</span>
+        Portada del artículo — 1600×900px, formato WebP comprimido
+      </div>
+    </div>
+  </div>
+
+  <div class="article-body">
+    <div class="wrap-article">
+
+      <p>Todo el mundo quiere hablar de anuncios antes de tiempo. Antes de poner un peso en publicidad, hay trabajo gratis que la mayoría de fotógrafos se salta, y sin ese trabajo previo, el anuncio más caro del mundo no convierte a nadie.</p>
+
+      <h2>Un anuncio no arregla una base rota</h2>
+      <p>Pagarle a Meta para mandar tráfico a un portafolio sin orden, sin propuesta clara y sin forma fácil de contactarte es pagar para que más gente vea algo que no convence a nadie. El anuncio amplifica lo que ya tienes, para bien o para mal.</p>
+
+      <blockquote>Un anuncio no crea confianza, la reparte más rápido. Si no hay confianza que repartir, solo estás pagando por visitas que se van igual de rápido que llegaron.</blockquote>
+
+      <h2>Tres cosas que sí puedes hacer ahora, gratis</h2>
+      <ul>
+        <li><strong>Ordena tu portafolio alrededor de un cliente ideal.</strong> No mezcles bodas con productos con mascotas. Un portafolio enfocado convierte más que uno "de todo un poco", porque le habla directo a la persona que lo mira.</li>
+        <li><strong>Escribe sobre las preguntas que te hacen por WhatsApp.</strong> Cada duda repetida de un cliente potencial es un tema de contenido ya validado. Contestarla en público te posiciona con quien todavía no te escribió.</li>
+        <li><strong>Pide la reseña en el momento correcto.</strong> Justo después de entregar el trabajo, cuando la satisfacción está más fresca, no semanas después cuando ya nadie se acuerda de escribirla.</li>
+      </ul>
+
+      <h2>Cuándo sí conviene pasar a anuncios</h2>
+      <p>Cuando ya tienes un portafolio que convierte, un proceso de venta que funciona y necesitas más volumen del que el orgánico te puede dar solo, ahí un anuncio bien dirigido multiplica lo que ya funciona. Antes de eso, cada peso en publicidad compite en desventaja contra el trabajo gratis que todavía no hiciste.</p>
+
+    </div>
+  </div>
+
+  <div class="wrap-article">
+    <div class="article-cta">
+      <h3>¿Ya hiciste el trabajo gratis y aun así no llegan clientes?</h3>
+      <p>Ahí es cuando conviene hablar de estrategia, no antes.</p>
+      <a class="btn btn-gold" href="https://api.whatsapp.com/send?phone=+59169422335&text=%C2%A1Hola%2C%20Pablo!%20Le%C3%AD%20el%20art%C3%ADculo%20de%20conseguir%20clientes%20sin%20ads%20y%20quiero%20saber%20m%C3%A1s%20de%20la%20comunidad" target="_blank" rel="noopener">Escríbeme por WhatsApp →</a>
+    </div>
+  </div>
+</article>
+
+<footer>
+  <div class="wrap">
+    <img src="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png" alt="The Marketographers" loading="lazy">
+    <p>© 2026 The Marketographers. Todos los putos derechos reservados.</p>
+  </div>
+</footer>
+
+<!-- Mismo mapeo de eventos de clic que usa la landing principal: chat.whatsapp.com
+     (grupo gratuito) = Lead, api.whatsapp.com/wa.me (chat directo) = Contact,
+     nas.com/nas.io (checkout) = ClickCheckoutLanding. Un solo listener delegado. -->
+<script>
+  document.addEventListener('click', (e)=>{
+    const link = e.target.closest('a');
+    if(!link || !link.href) return;
+    if(link.href.includes('chat.whatsapp.com')){
+      trackBoth('Lead');
+    } else if(link.href.includes('api.whatsapp.com') || link.href.includes('wa.me')){
+      trackBoth('Contact');
+    }
+    if(link.href.includes('nas.com') || link.href.includes('nas.io')){
+      trackBoth('ClickCheckoutLanding');
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/blog/cuanto-cobrar-fotografia-2026/index.html
+++ b/blog/cuanto-cobrar-fotografia-2026/index.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Cuánto deberías cobrar por una sesión de fotos en 2026 | The Marketographers</title>
+<meta name="description" content="Una forma simple de calcular tu tarifa real como fotógrafo en 2026, sin copiar el precio de otro ni quedarte corto por miedo a pedir de más.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://marketographers.com/blog/cuanto-cobrar-fotografia-2026/">
+
+<!-- Open Graph -->
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="The Marketographers">
+<meta property="og:title" content="Cuánto deberías cobrar por una sesión de fotos en 2026">
+<meta property="og:description" content="Una forma simple de calcular tu tarifa real, sin copiar el precio de otro ni quedarte corto por miedo a pedir de más.">
+<meta property="og:image" content="[URL_IMAGEN_PORTADA_1600x1000]">
+<meta property="og:url" content="https://marketographers.com/blog/cuanto-cobrar-fotografia-2026/">
+<meta property="og:locale" content="es_LA">
+<meta property="article:author" content="Pablo Villarroel">
+<meta property="article:published_time" content="2026-08-18">
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Cuánto deberías cobrar por una sesión de fotos en 2026">
+<meta name="twitter:description" content="Una forma simple de calcular tu tarifa real, sin copiar el precio de otro.">
+<meta name="twitter:image" content="[URL_IMAGEN_PORTADA_1600x1000]">
+
+<!-- Favicon -->
+<link rel="icon" type="image/png" href="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png">
+<link rel="apple-touch-icon" href="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png">
+
+<!-- JSON-LD -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Cuánto deberías cobrar por una sesión de fotos en 2026",
+  "description": "Una forma simple de calcular tu tarifa real, sin copiar el precio de otro ni quedarte corto por miedo a pedir de más.",
+  "image": "[URL_IMAGEN_PORTADA_1600x1000]",
+  "author": { "@type": "Person", "name": "Pablo Villarroel" },
+  "publisher": {
+    "@type": "EducationalOrganization",
+    "name": "The Marketographers",
+    "logo": { "@type": "ImageObject", "url": "https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png" }
+  },
+  "datePublished": "2026-08-18",
+  "dateModified": "2026-08-18",
+  "mainEntityOfPage": "https://marketographers.com/blog/cuanto-cobrar-fotografia-2026/"
+}
+</script>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/global.css">
+<link rel="stylesheet" href="/blog/assets/blog-extra.css">
+</head>
+<body>
+
+<!-- Meta Pixel. Mismo ID y mismo patrón anti-duplicados que el resto del sitio
+     (autoConfig apagado + Pixel/CAPI con el mismo event_id). Dispara PageView y
+     ViewContent con el título de este artículo, para poder armar en Meta la
+     audiencia "leyó el blog", más caliente que un visitante genérico. -->
+<script>
+!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+fbq('set', 'autoConfig', false, '467504537642622');
+fbq('init', '467504537642622');
+
+function makeEventId(prefix){
+  return prefix + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+}
+function getCookie(name){
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  return match ? match[2] : null;
+}
+function sendCapiEvent(eventName, eventId, customData){
+  try{
+    fetch('/.netlify/functions/capi', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({
+        event_name: eventName,
+        event_id: eventId,
+        event_source_url: window.location.href,
+        custom_data: customData || undefined,
+        fbp: getCookie('_fbp'),
+        fbc: getCookie('_fbc')
+      })
+    }).catch(()=>{});
+  }catch(e){}
+}
+function trackBoth(eventName, params){
+  const id = makeEventId(eventName.toLowerCase());
+  fbq('track', eventName, params || {}, {eventID:id});
+  sendCapiEvent(eventName, id, params);
+}
+
+trackBoth('PageView');
+trackBoth('ViewContent', {content_name:'Cuánto deberías cobrar por una sesión de fotos en 2026', content_type:'article'});
+</script>
+<noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=467504537642622&ev=PageView&noscript=1"/></noscript>
+
+<header>
+  <div class="nav wrap">
+    <a class="logo" href="/"><img src="https://res.cloudinary.com/dplhu2z6j/image/upload/v1755314905/Marketographers_Negro_S_F_tgh9z2.png" alt="The Marketographers"></a>
+    <div class="nav-actions">
+      <a class="btn btn-whatsapp" href="https://api.whatsapp.com/send?phone=+59169422335&text=%C2%A1Hola%2C%20Pablo!%20Vi%20tu%20blog%20y%20quiero%20m%C3%A1s%20info%20de%20la%20membres%C3%ADa%20de%20marketing%20para%20fot%C3%B3grafos" target="_blank" rel="noopener">WhatsApp</a>
+      <a class="btn btn-gold" href="/#planes">Únete</a>
+    </div>
+  </div>
+</header>
+
+<article>
+  <div class="article-hero">
+    <div class="wrap">
+      <span class="eyebrow eyebrow-red">Precio y ventas</span>
+      <h1>Cuánto deberías cobrar por una sesión de fotos en 2026</h1>
+      <div class="article-meta">
+        <span>Pablo Villarroel</span>
+        <span>18 de agosto, 2026</span>
+        <span>6 min de lectura</span>
+      </div>
+    </div>
+    <div class="wrap">
+      <div class="article-cover img-placeholder" style="aspect-ratio:16/9;">
+        <span class="ph-tag">Imagen por reemplazar</span>
+        Portada del artículo — 1600×900px, formato WebP comprimido
+      </div>
+    </div>
+  </div>
+
+  <div class="article-body">
+    <div class="wrap-article">
+
+      <p>"¿Cuánto cobro?" es la pregunta que más me hacen fotógrafos de todas las especialidades, y casi siempre la responden mal porque la hacen al revés: primero miran cuánto cobra la competencia y después intentan justificar ese número. Eso no es una tarifa, es una copia con margen de error.</p>
+
+      <h2>Tu tarifa no sale de lo que cobran los demás</h2>
+      <p>Lo que cobra otro fotógrafo incluye su renta, su equipo, su experiencia y su ciudad. Ninguno de esos números es el tuyo. Copiar un precio ajeno es copiar un negocio ajeno, y normalmente ese negocio tampoco está calculando bien sus números, así que terminas copiando un error.</p>
+
+      <blockquote>Una tarifa que no cubre tus costos reales no es un precio bajo, es un negocio que se está pagando a sí mismo para perder dinero.</blockquote>
+
+      <h2>La cuenta que sí tienes que hacer</h2>
+      <p>Antes de pensar en cuánto "se ve bien" cobrar, hay tres números que necesitas tener a mano:</p>
+      <ul>
+        <li><strong>Tus costos fijos mensuales.</strong> Equipo, software, transporte, edición si la subcontratas. Divide ese total entre cuántas sesiones puedes hacer al mes de forma realista.</li>
+        <li><strong>Tu hora real de trabajo.</strong> No es solo el día de la sesión: suma preproducción, edición, entrega y comunicación con el cliente. La mayoría subestima esto a la mitad.</li>
+        <li><strong>El margen que te permite vivir, no solo sobrevivir.</strong> Un precio que apenas cubre gastos no te deja invertir en mejorar equipo, aprender o tomarte una semana libre sin quebrar.</li>
+      </ul>
+
+      <h2>Lo que el cliente paga en realidad</h2>
+      <p>Nadie paga por el clic del obturador. Paga por el resultado y por la certeza de que va a salir bien: tu estilo, tu forma de dirigir la sesión, tu historial, cómo entregas el trabajo. Cuando tu precio está anclado solo en el tiempo que te toma, estás vendiendo horas. Cuando está anclado en el resultado que le das al cliente, estás vendiendo valor, y el valor sí se puede subir sin que se caiga la venta.</p>
+
+    </div>
+  </div>
+
+  <div class="wrap-article">
+    <div class="article-cta">
+      <h3>¿Sacaste la cuenta y el número te asustó?</h3>
+      <p>Es normal la primera vez. En la comunidad revisamos precios reales de fotógrafos como tú cada semana.</p>
+      <a class="btn btn-gold" href="https://api.whatsapp.com/send?phone=+59169422335&text=%C2%A1Hola%2C%20Pablo!%20Le%C3%AD%20el%20art%C3%ADculo%20de%20cu%C3%A1nto%20cobrar%20y%20quiero%20saber%20m%C3%A1s%20de%20la%20comunidad" target="_blank" rel="noopener">Escríbeme por WhatsApp →</a>
+    </div>
+  </div>
+</article>
+
+<footer>
+  <div class="wrap">
+    <img src="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png" alt="The Marketographers" loading="lazy">
+    <p>© 2026 The Marketographers. Todos los putos derechos reservados.</p>
+  </div>
+</footer>
+
+<!-- Mismo mapeo de eventos de clic que usa la landing principal: chat.whatsapp.com
+     (grupo gratuito) = Lead, api.whatsapp.com/wa.me (chat directo) = Contact,
+     nas.com/nas.io (checkout) = ClickCheckoutLanding. Un solo listener delegado. -->
+<script>
+  document.addEventListener('click', (e)=>{
+    const link = e.target.closest('a');
+    if(!link || !link.href) return;
+    if(link.href.includes('chat.whatsapp.com')){
+      trackBoth('Lead');
+    } else if(link.href.includes('api.whatsapp.com') || link.href.includes('wa.me')){
+      trackBoth('Contact');
+    }
+    if(link.href.includes('nas.com') || link.href.includes('nas.io')){
+      trackBoth('ClickCheckoutLanding');
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/blog/error-portafolio-fotografos/index.html
+++ b/blog/error-portafolio-fotografos/index.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>El error que comete el 95% de los fotógrafos con su portafolio | The Marketographers</title>
+<meta name="description" content="Un portafolio lleno de fotos bonitas no vende si no responde una pregunta: para quién es esto. El error más común de los fotógrafos, explicado.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://marketographers.com/blog/error-portafolio-fotografos/">
+
+<!-- Open Graph -->
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="The Marketographers">
+<meta property="og:title" content="El error que comete el 95% de los fotógrafos con su portafolio">
+<meta property="og:description" content="Un portafolio lleno de fotos bonitas no vende si no responde una pregunta: para quién es esto.">
+<meta property="og:image" content="[URL_IMAGEN_PORTADA_1600x1000]">
+<meta property="og:url" content="https://marketographers.com/blog/error-portafolio-fotografos/">
+<meta property="og:locale" content="es_LA">
+<meta property="article:author" content="Pablo Villarroel">
+<meta property="article:published_time" content="2026-08-18">
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="El error que comete el 95% de los fotógrafos con su portafolio">
+<meta name="twitter:description" content="Un portafolio lleno de fotos bonitas no vende si no responde: para quién es esto.">
+<meta name="twitter:image" content="[URL_IMAGEN_PORTADA_1600x1000]">
+
+<!-- Favicon -->
+<link rel="icon" type="image/png" href="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png">
+<link rel="apple-touch-icon" href="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png">
+
+<!-- JSON-LD -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "El error que comete el 95% de los fotógrafos con su portafolio",
+  "description": "Un portafolio lleno de fotos bonitas no vende si no responde una pregunta: para quién es esto.",
+  "image": "[URL_IMAGEN_PORTADA_1600x1000]",
+  "author": { "@type": "Person", "name": "Pablo Villarroel" },
+  "publisher": {
+    "@type": "EducationalOrganization",
+    "name": "The Marketographers",
+    "logo": { "@type": "ImageObject", "url": "https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png" }
+  },
+  "datePublished": "2026-08-18",
+  "dateModified": "2026-08-18",
+  "mainEntityOfPage": "https://marketographers.com/blog/error-portafolio-fotografos/"
+}
+</script>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/global.css">
+<link rel="stylesheet" href="/blog/assets/blog-extra.css">
+</head>
+<body>
+
+<!-- Meta Pixel. Mismo ID y mismo patrón anti-duplicados que el resto del sitio
+     (autoConfig apagado + Pixel/CAPI con el mismo event_id). Dispara PageView y
+     ViewContent con el título de este artículo, para poder armar en Meta la
+     audiencia "leyó el blog", más caliente que un visitante genérico. -->
+<script>
+!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+fbq('set', 'autoConfig', false, '467504537642622');
+fbq('init', '467504537642622');
+
+function makeEventId(prefix){
+  return prefix + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+}
+function getCookie(name){
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  return match ? match[2] : null;
+}
+function sendCapiEvent(eventName, eventId, customData){
+  try{
+    fetch('/.netlify/functions/capi', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({
+        event_name: eventName,
+        event_id: eventId,
+        event_source_url: window.location.href,
+        custom_data: customData || undefined,
+        fbp: getCookie('_fbp'),
+        fbc: getCookie('_fbc')
+      })
+    }).catch(()=>{});
+  }catch(e){}
+}
+function trackBoth(eventName, params){
+  const id = makeEventId(eventName.toLowerCase());
+  fbq('track', eventName, params || {}, {eventID:id});
+  sendCapiEvent(eventName, id, params);
+}
+
+trackBoth('PageView');
+trackBoth('ViewContent', {content_name:'El error que comete el 95% de los fotógrafos con su portafolio', content_type:'article'});
+</script>
+<noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=467504537642622&ev=PageView&noscript=1"/></noscript>
+
+<header>
+  <div class="nav wrap">
+    <a class="logo" href="/"><img src="https://res.cloudinary.com/dplhu2z6j/image/upload/v1755314905/Marketographers_Negro_S_F_tgh9z2.png" alt="The Marketographers"></a>
+    <div class="nav-actions">
+      <a class="btn btn-whatsapp" href="https://api.whatsapp.com/send?phone=+59169422335&text=%C2%A1Hola%2C%20Pablo!%20Vi%20tu%20blog%20y%20quiero%20m%C3%A1s%20info%20de%20la%20membres%C3%ADa%20de%20marketing%20para%20fot%C3%B3grafos" target="_blank" rel="noopener">WhatsApp</a>
+      <a class="btn btn-gold" href="/#planes">Únete</a>
+    </div>
+  </div>
+</header>
+
+<article>
+  <div class="article-hero">
+    <div class="wrap">
+      <span class="eyebrow eyebrow-red">Marca personal</span>
+      <h1>El error que comete el 95% de los fotógrafos al armar su portafolio</h1>
+      <div class="article-meta">
+        <span>Pablo Villarroel</span>
+        <span>18 de agosto, 2026</span>
+        <span>5 min de lectura</span>
+      </div>
+    </div>
+    <div class="wrap">
+      <div class="article-cover img-placeholder" style="aspect-ratio:16/9;">
+        <span class="ph-tag">Imagen por reemplazar</span>
+        Portada del artículo — 1600×900px, formato WebP comprimido
+      </div>
+    </div>
+  </div>
+
+  <div class="article-body">
+    <div class="wrap-article">
+
+      <p>Un portafolio con cien fotos hermosas puede vender menos que uno con veinte. La diferencia casi nunca es la calidad de las fotos, es que el de cien no responde una pregunta que el cliente se hace en los primeros tres segundos: ¿esto es para mí?</p>
+
+      <h2>El error: mostrar todo lo que sabes hacer</h2>
+      <p>Es tentador meter en el portafolio cada tipo de sesión que alguna vez hiciste, para "no cerrar puertas". El resultado es un portafolio que le habla a todo el mundo y por lo tanto no le habla a nadie en particular. Un cliente que busca fotógrafo de bodas, al ver bodas mezcladas con productos y retratos corporativos, no lee "versatilidad", lee "esto no es un especialista".</p>
+
+      <blockquote>Un portafolio que le habla a todos es un portafolio que no convence a nadie de que tú eres SU fotógrafo.</blockquote>
+
+      <h2>Cómo se ve un portafolio que sí filtra</h2>
+      <ul>
+        <li><strong>Empieza por tu mejor trabajo del nicho que quieres más.</strong> No el más reciente, el que mejor representa hacia dónde quieres que crezca tu negocio.</li>
+        <li><strong>Agrupa por tipo de cliente, no por fecha.</strong> Si atiendes dos nichos distintos, sepáralos en secciones o incluso en páginas distintas, nunca mezclados en una sola grilla.</li>
+        <li><strong>Corta lo que no representa tu mejor nivel actual.</strong> Una foto mediocre en medio de veinte buenas baja el promedio percibido de las veinte.</li>
+      </ul>
+
+      <h2>Menos fotos, más ventas</h2>
+      <p>El objetivo del portafolio no es demostrar que sabes tomar fotos, ya se asume que sabes. El objetivo es que la persona correcta, en tres segundos, sienta que encontró a alguien que entiende exactamente lo que necesita. Eso se logra con curaduría, no con volumen.</p>
+
+    </div>
+  </div>
+
+  <div class="wrap-article">
+    <div class="article-cta">
+      <h3>¿Tu portafolio le habla a todo el mundo y a nadie a la vez?</h3>
+      <p>Eso se arregla ordenando, no fotografiando más.</p>
+      <a class="btn btn-gold" href="https://api.whatsapp.com/send?phone=+59169422335&text=%C2%A1Hola%2C%20Pablo!%20Le%C3%AD%20el%20art%C3%ADculo%20del%20portafolio%20y%20quiero%20saber%20m%C3%A1s%20de%20la%20comunidad" target="_blank" rel="noopener">Escríbeme por WhatsApp →</a>
+    </div>
+  </div>
+</article>
+
+<footer>
+  <div class="wrap">
+    <img src="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png" alt="The Marketographers" loading="lazy">
+    <p>© 2026 The Marketographers. Todos los putos derechos reservados.</p>
+  </div>
+</footer>
+
+<!-- Mismo mapeo de eventos de clic que usa la landing principal: chat.whatsapp.com
+     (grupo gratuito) = Lead, api.whatsapp.com/wa.me (chat directo) = Contact,
+     nas.com/nas.io (checkout) = ClickCheckoutLanding. Un solo listener delegado. -->
+<script>
+  document.addEventListener('click', (e)=>{
+    const link = e.target.closest('a');
+    if(!link || !link.href) return;
+    if(link.href.includes('chat.whatsapp.com')){
+      trackBoth('Lead');
+    } else if(link.href.includes('api.whatsapp.com') || link.href.includes('wa.me')){
+      trackBoth('Contact');
+    }
+    if(link.href.includes('nas.com') || link.href.includes('nas.io')){
+      trackBoth('ClickCheckoutLanding');
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -50,6 +50,54 @@
 </head>
 <body>
 
+<!-- Meta Pixel. Mismo ID y mismo patrón anti-duplicados que el resto del sitio
+     (autoConfig apagado + Pixel/CAPI con el mismo event_id). Antes de este
+     cambio el blog no tenía pixel: las visitas y los clics acá no se medían. -->
+<script>
+!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+fbq('set', 'autoConfig', false, '467504537642622');
+fbq('init', '467504537642622');
+
+function makeEventId(prefix){
+  return prefix + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+}
+function getCookie(name){
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  return match ? match[2] : null;
+}
+function sendCapiEvent(eventName, eventId, customData){
+  try{
+    fetch('/.netlify/functions/capi', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({
+        event_name: eventName,
+        event_id: eventId,
+        event_source_url: window.location.href,
+        custom_data: customData || undefined,
+        fbp: getCookie('_fbp'),
+        fbc: getCookie('_fbc')
+      })
+    }).catch(()=>{});
+  }catch(e){}
+}
+function trackBoth(eventName, params){
+  const id = makeEventId(eventName.toLowerCase());
+  fbq('track', eventName, params || {}, {eventID:id});
+  sendCapiEvent(eventName, id, params);
+}
+
+trackBoth('PageView');
+</script>
+<noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=467504537642622&ev=PageView&noscript=1"/></noscript>
+
 <header>
   <div class="nav wrap">
     <a class="logo" href="/"><img src="https://res.cloudinary.com/dplhu2z6j/image/upload/v1755314905/Marketographers_Negro_S_F_tgh9z2.png" alt="The Marketographers"></a>
@@ -88,6 +136,61 @@
         </div>
       </a>
 
+      <a class="blog-card" href="/blog/cuanto-cobrar-fotografia-2026/">
+        <div class="img-placeholder" style="aspect-ratio:16/9;"><span class="ph-tag">Imagen por reemplazar</span></div>
+        <div class="blog-card-body">
+          <span class="tag">Precio y ventas</span>
+          <h3>Cuánto deberías cobrar por una sesión de fotos en 2026</h3>
+          <p>Una forma simple de calcular tu tarifa real, sin copiar el precio de otro ni quedarte corto.</p>
+          <span class="meta">Pablo Villarroel · 6 min de lectura</span>
+          <span class="read-more">Leer artículo</span>
+        </div>
+      </a>
+
+      <a class="blog-card" href="/blog/boca-a-boca-no-es-estrategia/">
+        <div class="img-placeholder" style="aspect-ratio:16/9;"><span class="ph-tag">Imagen por reemplazar</span></div>
+        <div class="blog-card-body">
+          <span class="tag">Posicionamiento</span>
+          <h3>Por qué el boca a boca no es una estrategia de marketing</h3>
+          <p>Vivir del boca a boca no es tener un negocio, es tener suerte con fecha de vencimiento.</p>
+          <span class="meta">Pablo Villarroel · 5 min de lectura</span>
+          <span class="read-more">Leer artículo</span>
+        </div>
+      </a>
+
+      <a class="blog-card" href="/blog/como-conseguir-clientes-sin-ads/">
+        <div class="img-placeholder" style="aspect-ratio:16/9;"><span class="ph-tag">Imagen por reemplazar</span></div>
+        <div class="blog-card-body">
+          <span class="tag">Captación de clientes</span>
+          <h3>Cómo conseguir clientes de fotografía sin gastar en anuncios (todavía)</h3>
+          <p>Antes de poner un peso en publicidad, hay trabajo gratis que la mayoría se salta.</p>
+          <span class="meta">Pablo Villarroel · 6 min de lectura</span>
+          <span class="read-more">Leer artículo</span>
+        </div>
+      </a>
+
+      <a class="blog-card" href="/blog/error-portafolio-fotografos/">
+        <div class="img-placeholder" style="aspect-ratio:16/9;"><span class="ph-tag">Imagen por reemplazar</span></div>
+        <div class="blog-card-body">
+          <span class="tag">Marca personal</span>
+          <h3>El error que comete el 95% de los fotógrafos al armar su portafolio</h3>
+          <p>Un portafolio que le habla a todos es un portafolio que no convence a nadie.</p>
+          <span class="meta">Pablo Villarroel · 5 min de lectura</span>
+          <span class="read-more">Leer artículo</span>
+        </div>
+      </a>
+
+      <a class="blog-card" href="/blog/objeciones-de-precio-fotografos/">
+        <div class="img-placeholder" style="aspect-ratio:16/9;"><span class="ph-tag">Imagen por reemplazar</span></div>
+        <div class="blog-card-body">
+          <span class="tag">Precio y ventas</span>
+          <h3>Cómo responder cuando un cliente te dice que estás caro</h3>
+          <p>"Está caro" casi nunca es sobre el precio. Cómo responder sin bajar tu tarifa.</p>
+          <span class="meta">Pablo Villarroel · 5 min de lectura</span>
+          <span class="read-more">Leer artículo</span>
+        </div>
+      </a>
+
     </div>
   </div>
 </section>
@@ -98,6 +201,25 @@
     <p>© 2026 The Marketographers. Todos los putos derechos reservados.</p>
   </div>
 </footer>
+
+<!-- Mismo mapeo de eventos de clic que usa la landing principal: chat.whatsapp.com
+     (grupo gratuito) = Lead, api.whatsapp.com/wa.me (chat directo) = Contact,
+     nas.com/nas.io (checkout) = ClickCheckoutLanding. Un solo listener delegado,
+     no uno por botón, para no arriesgar registrarlo dos veces por error. -->
+<script>
+  document.addEventListener('click', (e)=>{
+    const link = e.target.closest('a');
+    if(!link || !link.href) return;
+    if(link.href.includes('chat.whatsapp.com')){
+      trackBoth('Lead');
+    } else if(link.href.includes('api.whatsapp.com') || link.href.includes('wa.me')){
+      trackBoth('Contact');
+    }
+    if(link.href.includes('nas.com') || link.href.includes('nas.io')){
+      trackBoth('ClickCheckoutLanding');
+    }
+  });
+</script>
 
 </body>
 </html>

--- a/blog/objeciones-de-precio-fotografos/index.html
+++ b/blog/objeciones-de-precio-fotografos/index.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Cómo responder cuando un cliente te dice que estás caro | The Marketographers</title>
+<meta name="description" content="'Está caro' casi nunca es sobre el precio. Cómo responder a la objeción más común de fotografía sin bajar tu tarifa ni sonar a la defensiva.">
+<meta name="robots" content="index, follow">
+<link rel="canonical" href="https://marketographers.com/blog/objeciones-de-precio-fotografos/">
+
+<!-- Open Graph -->
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="The Marketographers">
+<meta property="og:title" content="Cómo responder cuando un cliente te dice que estás caro">
+<meta property="og:description" content="'Está caro' casi nunca es sobre el precio. Cómo responder sin bajar tu tarifa ni sonar a la defensiva.">
+<meta property="og:image" content="[URL_IMAGEN_PORTADA_1600x1000]">
+<meta property="og:url" content="https://marketographers.com/blog/objeciones-de-precio-fotografos/">
+<meta property="og:locale" content="es_LA">
+<meta property="article:author" content="Pablo Villarroel">
+<meta property="article:published_time" content="2026-08-18">
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Cómo responder cuando un cliente te dice que estás caro">
+<meta name="twitter:description" content="'Está caro' casi nunca es sobre el precio. Cómo responder sin bajar tu tarifa.">
+<meta name="twitter:image" content="[URL_IMAGEN_PORTADA_1600x1000]">
+
+<!-- Favicon -->
+<link rel="icon" type="image/png" href="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png">
+<link rel="apple-touch-icon" href="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png">
+
+<!-- JSON-LD -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "Cómo responder cuando un cliente te dice que estás caro",
+  "description": "'Está caro' casi nunca es sobre el precio. Cómo responder sin bajar tu tarifa ni sonar a la defensiva.",
+  "image": "[URL_IMAGEN_PORTADA_1600x1000]",
+  "author": { "@type": "Person", "name": "Pablo Villarroel" },
+  "publisher": {
+    "@type": "EducationalOrganization",
+    "name": "The Marketographers",
+    "logo": { "@type": "ImageObject", "url": "https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png" }
+  },
+  "datePublished": "2026-08-18",
+  "dateModified": "2026-08-18",
+  "mainEntityOfPage": "https://marketographers.com/blog/objeciones-de-precio-fotografos/"
+}
+</script>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/assets/global.css">
+<link rel="stylesheet" href="/blog/assets/blog-extra.css">
+</head>
+<body>
+
+<!-- Meta Pixel. Mismo ID y mismo patrón anti-duplicados que el resto del sitio
+     (autoConfig apagado + Pixel/CAPI con el mismo event_id). Dispara PageView y
+     ViewContent con el título de este artículo, para poder armar en Meta la
+     audiencia "leyó el blog", más caliente que un visitante genérico. -->
+<script>
+!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+fbq('set', 'autoConfig', false, '467504537642622');
+fbq('init', '467504537642622');
+
+function makeEventId(prefix){
+  return prefix + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+}
+function getCookie(name){
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  return match ? match[2] : null;
+}
+function sendCapiEvent(eventName, eventId, customData){
+  try{
+    fetch('/.netlify/functions/capi', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({
+        event_name: eventName,
+        event_id: eventId,
+        event_source_url: window.location.href,
+        custom_data: customData || undefined,
+        fbp: getCookie('_fbp'),
+        fbc: getCookie('_fbc')
+      })
+    }).catch(()=>{});
+  }catch(e){}
+}
+function trackBoth(eventName, params){
+  const id = makeEventId(eventName.toLowerCase());
+  fbq('track', eventName, params || {}, {eventID:id});
+  sendCapiEvent(eventName, id, params);
+}
+
+trackBoth('PageView');
+trackBoth('ViewContent', {content_name:'Cómo responder cuando un cliente te dice que estás caro', content_type:'article'});
+</script>
+<noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=467504537642622&ev=PageView&noscript=1"/></noscript>
+
+<header>
+  <div class="nav wrap">
+    <a class="logo" href="/"><img src="https://res.cloudinary.com/dplhu2z6j/image/upload/v1755314905/Marketographers_Negro_S_F_tgh9z2.png" alt="The Marketographers"></a>
+    <div class="nav-actions">
+      <a class="btn btn-whatsapp" href="https://api.whatsapp.com/send?phone=+59169422335&text=%C2%A1Hola%2C%20Pablo!%20Vi%20tu%20blog%20y%20quiero%20m%C3%A1s%20info%20de%20la%20membres%C3%ADa%20de%20marketing%20para%20fot%C3%B3grafos" target="_blank" rel="noopener">WhatsApp</a>
+      <a class="btn btn-gold" href="/#planes">Únete</a>
+    </div>
+  </div>
+</header>
+
+<article>
+  <div class="article-hero">
+    <div class="wrap">
+      <span class="eyebrow eyebrow-red">Precio y ventas</span>
+      <h1>Cómo responder cuando un cliente te dice que estás caro</h1>
+      <div class="article-meta">
+        <span>Pablo Villarroel</span>
+        <span>18 de agosto, 2026</span>
+        <span>5 min de lectura</span>
+      </div>
+    </div>
+    <div class="wrap">
+      <div class="article-cover img-placeholder" style="aspect-ratio:16/9;">
+        <span class="ph-tag">Imagen por reemplazar</span>
+        Portada del artículo — 1600×900px, formato WebP comprimido
+      </div>
+    </div>
+  </div>
+
+  <div class="article-body">
+    <div class="wrap-article">
+
+      <p>"Está caro" es la frase que más nervios pone a un fotógrafo, y también la que peor se responde en caliente. La reacción automática es defenderse o bajar el precio en el acto. Ninguna de las dos resuelve lo que el cliente en realidad está diciendo.</p>
+
+      <h2>"Caro" casi nunca significa lo que crees</h2>
+      <p>Cuando alguien dice que estás caro, en la mayoría de los casos no está comparando tu precio contra su presupuesto. Lo está comparando contra el valor que todavía no le quedó claro que vas a entregar. Es una objeción de percepción, no de bolsillo, y se resuelve con más claridad, no con más descuento.</p>
+
+      <blockquote>Nadie negocia el precio de algo cuyo valor ya tiene clarísimo. La objeción de precio casi siempre es una objeción de valor disfrazada.</blockquote>
+
+      <h2>Cómo responder sin bajar la tarifa</h2>
+      <ul>
+        <li><strong>No respondas de inmediato con un número más bajo.</strong> Pregunta primero qué esperaba invertir y qué es lo que más le importa del resultado. Ahí aparece la objeción real.</li>
+        <li><strong>Explica qué incluye ese precio, en concreto.</strong> Horas de edición, entregables, licencias de uso, tiempo de respuesta. Lo invisible del proceso es justo lo que el cliente no está viendo cuando dice "caro".</li>
+        <li><strong>Ofrece opciones, no descuentos.</strong> Si el presupuesto es real, ajusta el alcance (menos horas, menos entregables) antes que el precio por el mismo trabajo completo.</li>
+      </ul>
+
+      <h2>Cuando sí es que de verdad no puede pagarte</h2>
+      <p>A veces la objeción es real: el presupuesto del cliente simplemente no alcanza para lo que ofreces, y está bien dejarlo ir. No todo cliente es tu cliente. Bajar la tarifa para cerrar una venta que estructuralmente no calzaba solo entrena a tus próximos clientes a pedirte lo mismo.</p>
+
+    </div>
+  </div>
+
+  <div class="wrap-article">
+    <div class="article-cta">
+      <h3>¿Se te congela la cabeza cuando te dicen "está caro"?</h3>
+      <p>Ese guion se entrena, no se improvisa cada vez.</p>
+      <a class="btn btn-gold" href="https://api.whatsapp.com/send?phone=+59169422335&text=%C2%A1Hola%2C%20Pablo!%20Le%C3%AD%20el%20art%C3%ADculo%20de%20objeciones%20de%20precio%20y%20quiero%20saber%20m%C3%A1s%20de%20la%20comunidad" target="_blank" rel="noopener">Escríbeme por WhatsApp →</a>
+    </div>
+  </div>
+</article>
+
+<footer>
+  <div class="wrap">
+    <img src="https://res.cloudinary.com/dplhu2z6j/image/upload/q_auto,f_auto/v1755314903/Marketographers_Blanco_S_F_p1toov.png" alt="The Marketographers" loading="lazy">
+    <p>© 2026 The Marketographers. Todos los putos derechos reservados.</p>
+  </div>
+</footer>
+
+<!-- Mismo mapeo de eventos de clic que usa la landing principal: chat.whatsapp.com
+     (grupo gratuito) = Lead, api.whatsapp.com/wa.me (chat directo) = Contact,
+     nas.com/nas.io (checkout) = ClickCheckoutLanding. Un solo listener delegado. -->
+<script>
+  document.addEventListener('click', (e)=>{
+    const link = e.target.closest('a');
+    if(!link || !link.href) return;
+    if(link.href.includes('chat.whatsapp.com')){
+      trackBoth('Lead');
+    } else if(link.href.includes('api.whatsapp.com') || link.href.includes('wa.me')){
+      trackBoth('Contact');
+    }
+    if(link.href.includes('nas.com') || link.href.includes('nas.io')){
+      trackBoth('ClickCheckoutLanding');
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>The Marketographers | Marketing para fotógrafos - Pablo Villarroel</title>
-<meta name="description" content="La comunidad de marketing para fotógrafos más activa del mundo. Clases en vivo 2x por semana, cursos ilimitados y una comunidad que te empuja a vender mejor tu trabajo.">
+<meta name="description" content="La comunidad de marketing para fotógrafos más activa del mundo. Clases en vivo 2x por semana y una comunidad que te empuja a vender mejor tu trabajo.">
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="https://marketographers.com/">
 
@@ -34,9 +34,48 @@
   "@type": "EducationalOrganization",
   "name": "The Marketographers",
   "url": "https://marketographers.com/",
-  "founder": { "@type": "Person", "name": "Pablo Villarroel" },
+  "founder": { "@type": "Person", "name": "Pablo Villarroel", "url": "https://marketographers.com/#pablo" },
   "description": "Comunidad de marketing para fotógrafos con clases en vivo, cursos y mentoría.",
-  "sameAs": []
+  "sameAs": [
+    "https://www.instagram.com/themarketographer/",
+    "https://www.tiktok.com/@themarketographer",
+    "https://chat.whatsapp.com/H87amNgVpRr0g2habJsfjd"
+  ]
+}
+</script>
+
+<!-- JSON-LD: FAQPage. Mismas preguntas y respuestas visibles en la sección de FAQ, palabra por palabra, para que coincidan con lo que Google y las IAs indexan del HTML visible. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Tienen garantía de devolución?",
+      "acceptedAnswer": { "@type": "Answer", "text": "No. Aquí no devolvemos dinero porque sabemos que, si entras, vas a querer quedarte. Si pensabas entrar para pedir una devolución probablemente es porque esperabas milagros sin mover un dedo." }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cuánto tiempo tengo que dedicarle?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Las clases en vivo son 2 veces por semana (2-3 horas). El resto del contenido lo puedes consumir a tu ritmo. El grupo está activo 24/7, pero tú decides cuánto participar." }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo sé si esto es para mí?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Si eres fotógrafo y quieres más clientes, más tiempo libre y dejar de vivir del boca a boca, esto es para ti." }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Y si no sé nada de marketing?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Mejor. Así no tienes que desaprender cosas que te dijeron gurús del marketing sobre 'contenido de valor' o 'videos virales con IA'." }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Y siempre dices groserías?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Sí, bastante. Porque decir 'cliente de mierda' es más potente que decir 'cliente poco comprometido'." }
+    }
+  ]
 }
 </script>
 
@@ -430,7 +469,7 @@ function getCookie(name){
   const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
   return match ? match[2] : null;
 }
-function sendCapiEvent(eventName, eventId){
+function sendCapiEvent(eventName, eventId, customData){
   try{
     fetch('/.netlify/functions/capi', {
       method:'POST',
@@ -439,16 +478,17 @@ function sendCapiEvent(eventName, eventId){
         event_name: eventName,
         event_id: eventId,
         event_source_url: window.location.href,
+        custom_data: customData || undefined,
         fbp: getCookie('_fbp'),
         fbc: getCookie('_fbc')
       })
     }).catch(()=>{});
   }catch(e){}
 }
-function trackBoth(eventName){
+function trackBoth(eventName, params){
   const id = makeEventId(eventName.toLowerCase());
-  fbq('track', eventName, {}, {eventID:id});
-  sendCapiEvent(eventName, id);
+  fbq('track', eventName, params || {}, {eventID:id});
+  sendCapiEvent(eventName, id, params);
 }
 
 trackBoth('PageView');

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,14 @@
+# The Marketographers
+
+> Comunidad de marketing para fotógrafos: clases en vivo, mentoría y estrategias de venta y posicionamiento, liderada por Pablo Villarroel (@themarketographer).
+
+## Páginas principales
+
+- [Inicio](https://marketographers.com/): quién es The Marketographers, qué incluye la membresía Motion, testimonios de fotógrafos y preguntas frecuentes.
+- [Blog](https://marketographers.com/blog/): artículos sobre precio, ventas, posicionamiento y captación de clientes para fotógrafos.
+- [Por qué bajar tus precios no te trae más clientes](https://marketographers.com/blog/como-cobrar-mas-sin-bajar-precio/)
+- [Cuánto deberías cobrar por una sesión de fotos en 2026](https://marketographers.com/blog/cuanto-cobrar-fotografia-2026/)
+- [Por qué el boca a boca no es una estrategia de marketing](https://marketographers.com/blog/boca-a-boca-no-es-estrategia/)
+- [Cómo conseguir clientes de fotografía sin gastar en anuncios](https://marketographers.com/blog/como-conseguir-clientes-sin-ads/)
+- [El error que comete el 95% de los fotógrafos al armar su portafolio](https://marketographers.com/blog/error-portafolio-fotografos/)
+- [Cómo responder cuando un cliente te dice que estás caro](https://marketographers.com/blog/objeciones-de-precio-fotografos/)

--- a/masterclass/index.html
+++ b/masterclass/index.html
@@ -25,19 +25,64 @@
 <!-- Misma hoja de estilos que usa el resto del sitio. -->
 <link rel="stylesheet" href="https://marketographers.com/assets/global.css">
 
-<!-- Mismo Pixel principal de siempre. Ademas del PageView estandar,
-     dispara un evento personalizado (ViewMasterclassLanding) para
-     poder armar campanas y publicos separados de esta pagina en
-     particular, sin mezclarlos con las visitas a la landing general. -->
+<!-- Mismo Pixel principal de siempre, con el mismo patrón anti-duplicados que usa
+     la landing principal: autoConfig apagado (si no, Meta detecta automáticamente
+     clics y los cuenta aparte de los eventos manuales de acá abajo, duplicando
+     señal) y cada evento viaja por Pixel + Conversions API con el mismo event_id,
+     así Meta descarta la copia repetida en vez de contar dos veces.
+     Además del PageView estándar, dispara un evento personalizado
+     (ViewMasterclassLanding) para poder armar campañas y públicos separados de
+     esta página, sin mezclarlos con las visitas a la landing general. -->
 <script>
 !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
 n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
 n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
 t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
 document,'script','https://connect.facebook.net/en_US/fbevents.js');
+fbq('set', 'autoConfig', false, '467504537642622');
 fbq('init', '467504537642622');
-fbq('track', 'PageView');
-fbq('trackCustom', 'ViewMasterclassLanding');
+
+function makeEventId(prefix){
+  return prefix + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+}
+function getCookie(name){
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  return match ? match[2] : null;
+}
+function sendCapiEvent(eventName, eventId, customData){
+  try{
+    fetch('/.netlify/functions/capi', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({
+        event_name: eventName,
+        event_id: eventId,
+        event_source_url: window.location.href,
+        custom_data: customData || undefined,
+        fbp: getCookie('_fbp'),
+        fbc: getCookie('_fbc')
+      })
+    }).catch(()=>{});
+  }catch(e){}
+}
+function trackBoth(eventName, params){
+  const id = makeEventId(eventName.toLowerCase());
+  fbq('track', eventName, params || {}, {eventID:id});
+  sendCapiEvent(eventName, id, params);
+}
+// Igual que trackBoth pero para eventos que NO son del catálogo estándar de Meta
+// (fbq('track', ...) con un nombre no estándar dispara una advertencia en consola
+// y Meta lo trata distinto en reportes). ViewMasterclassLanding es un evento propio
+// a propósito, para no mezclar esta audiencia con el ViewContent genérico de la
+// landing principal ni con el de los posts del blog.
+function trackCustomBoth(eventName, params){
+  const id = makeEventId(eventName.toLowerCase());
+  fbq('trackCustom', eventName, params || {}, {eventID:id});
+  sendCapiEvent(eventName, id, params);
+}
+
+trackBoth('PageView');
+trackCustomBoth('ViewMasterclassLanding');
 </script>
 <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=467504537642622&ev=PageView&noscript=1"/></noscript>
 
@@ -174,6 +219,26 @@ fbq('trackCustom', 'ViewMasterclassLanding');
   Cal.ns["ventas-para-fotografos"]("ui", {"theme":"light","cssVarsPerTheme":{"light":{"cal-brand":"#F5B729"},"dark":{"cal-brand":"#F5B729"}},"hideEventTypeDetails":false,"layout":"month_view"});
 </script>
 <!-- Cal element-click embed code ends -->
+
+<!-- Meta Pixel: clics, no confirmaciones. La confirmación real de la reserva
+     (cuando alguien efectivamente agenda) la manda el webhook de Cal.com desde
+     el servidor (netlify/functions/cal-webhook.js), una sola vez por reserva.
+     Si acá también disparáramos un evento al confirmar la reserva sin compartir
+     el mismo event_id con el webhook, Meta contaría la misma persona dos veces:
+     una por el navegador y otra por el servidor. Por eso acá solo se mide la
+     intención de clic (abrir el widget), nunca la reserva confirmada. -->
+<script>
+  document.addEventListener('click', (e)=>{
+    const link = e.target.closest('a, button');
+    if(!link) return;
+    if(link.href && link.href.includes('chat.whatsapp.com')){
+      trackBoth('Lead');
+    }
+    if(link.dataset && link.dataset.calLink){
+      trackCustomBoth('ClickRegisterMasterclass');
+    }
+  });
+</script>
 
 </body>
 </html>

--- a/netlify/functions/cal-webhook.js
+++ b/netlify/functions/cal-webhook.js
@@ -1,14 +1,18 @@
 // netlify/functions/cal-webhook.js
 //
 // Qué hace este archivo, en orden:
-// 1. Recibe el POST que Cal.com manda cada vez que alguien agenda una llamada.
+// 1. Recibe el POST que Cal.com manda cada vez que alguien agenda un evento.
 // 2. Verifica que el aviso venga realmente de Cal.com (usando CALCOM_WEBHOOK_SECRET).
-// 3. Saca el correo, nombre y teléfono de quien agendó.
-// 4. Los hashea (SHA256), porque Meta nunca acepta datos personales en texto plano.
-// 5. Busca la audiencia "Agendaron llamada de admisiones - Marketographers" en Meta;
-//    si no existe todavía, la crea.
-// 6. Agrega a esa persona a la audiencia.
-// 7. Manda el evento de conversión a la Conversions API de Meta (CAPI).
+// 3. Mira de qué tipo de evento de Cal.com se trata (admisiones o masterclass) y
+//    elige la audiencia y el evento de conversión que le corresponden, en
+//    EVENT_TYPE_CONFIG. Un tipo de evento que no esté ahí se ignora, no se mezcla.
+// 4. Saca el correo, nombre y teléfono de quien agendó.
+// 5. Los hashea (SHA256), porque Meta nunca acepta datos personales en texto plano.
+// 6. Busca la audiencia que corresponde en Meta; si no existe todavía, la crea.
+// 7. Agrega a esa persona a la audiencia.
+// 8. Manda el evento de conversión a la Conversions API de Meta (CAPI), con un
+//    event_id con prefijo por tipo de evento para que nunca compita en el
+//    dedup con el de otro embudo.
 //
 // Variables de entorno que esta función necesita (ya las pusiste en Netlify):
 //   META_ACCESS_TOKEN       -> token del Usuario del Sistema "Netlify Cal Webhook"
@@ -19,7 +23,26 @@
 const crypto = require('crypto');
 
 const GRAPH_API_VERSION = 'v21.0';
-const AUDIENCE_NAME = 'Agendaron llamada de admisiones - Marketographers';
+
+// Cada tipo de evento de Cal.com que nos interesa tiene su propia audiencia y su
+// propio evento de conversión, para no mezclar en un mismo balde a alguien que
+// agendó una llamada de ventas 1 a 1 con alguien que se registró a una
+// masterclass gratuita: son intenciones de compra distintas y Meta optimiza
+// mejor cuando el evento refleja eso.
+const EVENT_TYPE_CONFIG = {
+  admisiones: {
+    audienceName: 'Agendaron llamada de admisiones - Marketographers',
+    audienceDescription: 'Gente que agendó llamada de admisiones vía Cal.com (creada automáticamente)',
+    eventName: 'Lead',
+    eventIdPrefix: 'admisiones',
+  },
+  'ventas-para-fotografos': {
+    audienceName: 'Registraron masterclass - Marketographers',
+    audienceDescription: 'Gente que se registró a la masterclass gratuita vía Cal.com (creada automáticamente)',
+    eventName: 'CompleteRegistration',
+    eventIdPrefix: 'masterclass',
+  },
+};
 
 // ---------- Utilidades ----------
 
@@ -52,7 +75,7 @@ function isValidSignature(rawBody, signatureHeader, secret) {
 
 // ---------- Llamadas a la API de Meta ----------
 
-async function findOrCreateAudience(adAccountId, accessToken) {
+async function findOrCreateAudience(adAccountId, accessToken, audienceName, audienceDescription) {
   // 1. Buscar si ya existe una audiencia con este nombre exacto.
   const searchUrl = `https://graph.facebook.com/${GRAPH_API_VERSION}/act_${adAccountId}/customaudiences?fields=id,name&limit=200&access_token=${accessToken}`;
   const searchRes = await fetch(searchUrl);
@@ -62,7 +85,7 @@ async function findOrCreateAudience(adAccountId, accessToken) {
     throw new Error(`Error buscando audiencias: ${JSON.stringify(searchData.error)}`);
   }
 
-  const existing = (searchData.data || []).find((aud) => aud.name === AUDIENCE_NAME);
+  const existing = (searchData.data || []).find((aud) => aud.name === audienceName);
   if (existing) {
     return existing.id;
   }
@@ -73,9 +96,9 @@ async function findOrCreateAudience(adAccountId, accessToken) {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      name: AUDIENCE_NAME,
+      name: audienceName,
       subtype: 'CUSTOM',
-      description: 'Gente que agendó llamada de admisiones vía Cal.com (creada automáticamente)',
+      description: audienceDescription,
       customer_file_source: 'USER_PROVIDED_ONLY',
       access_token: accessToken,
     }),
@@ -128,7 +151,7 @@ async function addUserToAudience(audienceId, hashedEmail, hashedPhone, accessTok
   return data;
 }
 
-async function sendConversionEvent({ pixelId, accessToken, hashedEmail, hashedPhone, eventTime, eventId }) {
+async function sendConversionEvent({ pixelId, accessToken, hashedEmail, hashedPhone, eventTime, eventId, eventName }) {
   const url = `https://graph.facebook.com/${GRAPH_API_VERSION}/${pixelId}/events`;
 
   const userData = {};
@@ -141,7 +164,7 @@ async function sendConversionEvent({ pixelId, accessToken, hashedEmail, hashedPh
     body: JSON.stringify({
       data: [
         {
-          event_name: 'Lead',
+          event_name: eventName,
           event_time: eventTime,
           event_id: eventId, // evita duplicados si el pixel del navegador también mandó este evento
           action_source: 'system_generated',
@@ -193,17 +216,19 @@ exports.handler = async (event) => {
     return { statusCode: 200, body: 'Evento ignorado (no es BOOKING_CREATED)' };
   }
 
-  // Solo nos interesan las reservas del tipo de evento "admisiones"
-  // (https://cal.com/themarketographer/admisiones). Cualquier otro
-  // tipo de evento que tengas en Cal.com se ignora acá.
+  // Solo nos interesan las reservas de los tipos de evento que tenemos mapeados
+  // en EVENT_TYPE_CONFIG (hoy: "admisiones" y "ventas-para-fotografos"). Si en
+  // Cal.com se crea un tipo de evento nuevo y no se agrega acá, se ignora en vez
+  // de mezclarse por accidente con una audiencia que no le corresponde.
   const eventSlug = (
     payload.payload?.eventType?.slug ||
     payload.payload?.type ||
     ''
   ).toLowerCase();
 
-  if (eventSlug !== 'admisiones') {
-    console.log(`Reserva ignorada: es del tipo de evento "${eventSlug}", no "admisiones".`);
+  const eventConfig = EVENT_TYPE_CONFIG[eventSlug];
+  if (!eventConfig) {
+    console.log(`Reserva ignorada: el tipo de evento "${eventSlug}" no está mapeado en EVENT_TYPE_CONFIG.`);
     return { statusCode: 200, body: `Evento ignorado (tipo de evento: ${eventSlug || 'desconocido'})` };
   }
 
@@ -223,20 +248,28 @@ exports.handler = async (event) => {
       return { statusCode: 200, body: 'Sin datos de contacto, nada que hacer' };
     }
 
-    // 2. Encontrar o crear la audiencia.
-    const audienceId = await findOrCreateAudience(META_AD_ACCOUNT_ID, META_ACCESS_TOKEN);
+    // 2. Encontrar o crear la audiencia que corresponde a este tipo de evento.
+    const audienceId = await findOrCreateAudience(
+      META_AD_ACCOUNT_ID,
+      META_ACCESS_TOKEN,
+      eventConfig.audienceName,
+      eventConfig.audienceDescription
+    );
 
     // 3. Agregar a la persona a la audiencia.
     await addUserToAudience(audienceId, hashedEmail, hashedPhone, META_ACCESS_TOKEN);
 
-    // 4. Mandar el evento de conversión server-side.
+    // 4. Mandar el evento de conversión server-side. El event_id lleva un prefijo
+    // distinto por tipo de evento (admisiones_ / masterclass_) para que nunca
+    // pueda pisarse con el de otro embudo aunque el bookingUid coincidiera.
     await sendConversionEvent({
       pixelId: META_PIXEL_ID,
       accessToken: META_ACCESS_TOKEN,
       hashedEmail,
       hashedPhone,
       eventTime,
-      eventId: bookingUid,
+      eventId: `${eventConfig.eventIdPrefix}_${bookingUid}`,
+      eventName: eventConfig.eventName,
     });
 
     return {

--- a/netlify/functions/capi.js
+++ b/netlify/functions/capi.js
@@ -19,7 +19,7 @@ exports.handler = async (event) => {
 
   try {
     const body = JSON.parse(event.body || '{}');
-    const { event_name, event_id, event_source_url, fbp, fbc } = body;
+    const { event_name, event_id, event_source_url, fbp, fbc, custom_data } = body;
 
     if (!event_name || !event_id) {
       return { statusCode: 400, body: JSON.stringify({ error: 'Falta event_name o event_id' }) };
@@ -47,6 +47,7 @@ exports.handler = async (event) => {
           event_source_url,
           action_source: 'website',
           user_data: userData,
+          ...(custom_data ? { custom_data } : {}),
         },
       ],
     };

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -18,4 +18,34 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://marketographers.com/blog/cuanto-cobrar-fotografia-2026/</loc>
+    <lastmod>2026-08-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://marketographers.com/blog/boca-a-boca-no-es-estrategia/</loc>
+    <lastmod>2026-08-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://marketographers.com/blog/como-conseguir-clientes-sin-ads/</loc>
+    <lastmod>2026-08-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://marketographers.com/blog/error-portafolio-fotografos/</loc>
+    <lastmod>2026-08-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://marketographers.com/blog/objeciones-de-precio-fotografos/</loc>
+    <lastmod>2026-08-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
Correcciones de SEO/GEO y tracking en marketographers.com:

- Se elimino store.marketographers del Search Console (dominio muerto).
- - Se agregaron llms.txt y ai.txt para IAs y buscadores.
- - FAQ schema (FAQPage) en la home, con las mismas preguntas y respuestas visibles.
- - Meta description mas corta, JSON-LD de EducationalOrganization con redes sociales.
- - Se agregaron 5 posts nuevos al blog (borradores, listos para que Pablo cambie foto y texto): cuanto cobrar en 2026, boca a boca, clientes sin ads, error de portafolio, objeciones de precio.
- - sitemap.xml y llms.txt actualizados con los posts nuevos.
- - Meta Pixel y Conversions API (CAPI) revisados en todas las paginas: mismo event_id entre pixel y CAPI para evitar eventos duplicados, eventos claros por pagina (Lead, Contact, ClickCheckoutLanding, ViewContent, eventos propios en /masterclass).
- - capi.js actualizado para mandar custom_data al servidor de Meta.
- - cal-webhook.js separado por tipo de evento (admisiones vs masterclass) para que las audiencias y el CAPI no se mezclen entre embudos.
Todo esto ya esta commiteado directo en la rama seo-geo-tracking-fixes, lista para revisar y mergear a main.